### PR TITLE
Remove hover cues from logo

### DIFF
--- a/css/skeleton.css
+++ b/css/skeleton.css
@@ -474,6 +474,7 @@ there.
   text-align: center;
   padding: 4px 4px;
   text-decoration: none;
+  cursor: default;
 }
 
 #menu_bar_item_img img {
@@ -481,7 +482,8 @@ there.
 }
 
 #menu_bar_item_img a:hover {
-  background-color: #111;
+  background-color: inherit;
+  cursor: default;
 }
 /********END of clickable imgs**************/
 


### PR DESCRIPTION
## Summary
- hide pointer on hover for the menu logo link
- prevent the logo background color from changing on hover

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684039ce68448333bca0723f35e14339